### PR TITLE
updated legend symbol

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.7",
       "license": "MIT",
       "dependencies": {
-        "@watergis/legend-symbol": "^0.2.2",
+        "@watergis/legend-symbol": "^0.2.3",
         "axios": "^0.27.2",
         "maplibre-gl": "^2.4.0"
       },
@@ -371,9 +371,9 @@
       }
     },
     "node_modules/@watergis/legend-symbol": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@watergis/legend-symbol/-/legend-symbol-0.2.2.tgz",
-      "integrity": "sha512-Dj7uj8ikqsv1AgaMSC5/Z5rGRxg0i8SMpBGC8AfTljwG1EsaSY9qD0Oe65/lEAabmt7WjA9HYaObf8ySuQA94g==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@watergis/legend-symbol/-/legend-symbol-0.2.3.tgz",
+      "integrity": "sha512-bxW2nGUvL80/iLTAstvP0QRcpprKKyTOLFueDW+dD0g9PDIFYx4De6MrKp4QJPx9SmrlidPxslOB0mXZrENmUg==",
       "dependencies": {
         "@mapbox/mapbox-gl-style-spec": "^13.16.0"
       }
@@ -4739,9 +4739,9 @@
       }
     },
     "@watergis/legend-symbol": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@watergis/legend-symbol/-/legend-symbol-0.2.2.tgz",
-      "integrity": "sha512-Dj7uj8ikqsv1AgaMSC5/Z5rGRxg0i8SMpBGC8AfTljwG1EsaSY9qD0Oe65/lEAabmt7WjA9HYaObf8ySuQA94g==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@watergis/legend-symbol/-/legend-symbol-0.2.3.tgz",
+      "integrity": "sha512-bxW2nGUvL80/iLTAstvP0QRcpprKKyTOLFueDW+dD0g9PDIFYx4De6MrKp4QJPx9SmrlidPxslOB0mXZrENmUg==",
       "requires": {
         "@mapbox/mapbox-gl-style-spec": "^13.16.0"
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "webpack-dev-server": "^4.11.0"
   },
   "dependencies": {
-    "@watergis/legend-symbol": "^0.2.2",
+    "@watergis/legend-symbol": "^0.2.3",
     "axios": "^0.27.2",
     "maplibre-gl": "^2.4.0"
   }


### PR DESCRIPTION
updated `legend-symbol` to provide line-dash array legend now (https://github.com/watergis/legend-symbol/pull/1)