### PR TITLE
fix: add error handling when sprite@2x.png is not reachable

### DIFF
--- a/.changeset/small-steaks-refuse.md
+++ b/.changeset/small-steaks-refuse.md
@@ -1,0 +1,5 @@
+---
+"@watergis/maplibre-gl-legend": patch
+---
+
+fix: add error handling when sprite@2x.png is not reachable

--- a/packages/maplibre-gl-legend/src/lib/index.ts
+++ b/packages/maplibre-gl-legend/src/lib/index.ts
@@ -424,7 +424,6 @@ export class MaplibreLegendControl implements IControl {
 				if (!cancelled) resolve(img);
 			};
 			img.onerror = (e) => {
-				console.log(e);
 				if (!cancelled) reject(e);
 			};
 			img.src = url;

--- a/packages/maplibre-gl-legend/src/lib/index.ts
+++ b/packages/maplibre-gl-legend/src/lib/index.ts
@@ -350,9 +350,11 @@ export class MaplibreLegendControl implements IControl {
 					this.loadImage(`${styleUrl}@2x.png`),
 					this.loadJson(`${styleUrl}.json`)
 				]);
-				await promise.then(([image, json]) => {
-					this.setSprite(image, json);
-				});
+				await promise
+					.then(([image, json]) => {
+						this.setSprite(image, json);
+					})
+					.catch((err) => console.error(err));
 				this.updateLegendControl();
 				map.off('idle', afterLoadListener);
 			}
@@ -422,6 +424,7 @@ export class MaplibreLegendControl implements IControl {
 				if (!cancelled) resolve(img);
 			};
 			img.onerror = (e) => {
+				console.log(e);
 				if (!cancelled) reject(e);
 			};
 			img.src = url;


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Please describe what you changed briefly.

## Type of Pull Request
<!-- ignore-task-list-start -->
- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] Make sure all the exsiting features working well
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-legend/tree/master/.github/CONTRIBUTING.md) for more details.
