### PR TITLE
 fix: only load sprite file if sprite property in style is available

### DIFF
--- a/.changeset/grumpy-eggs-greet.md
+++ b/.changeset/grumpy-eggs-greet.md
@@ -1,0 +1,5 @@
+---
+"@watergis/maplibre-gl-legend": patch
+---
+
+fix: only load sprite file if sprite property in style is available

--- a/packages/maplibre-gl-legend/src/lib/index.ts
+++ b/packages/maplibre-gl-legend/src/lib/index.ts
@@ -346,15 +346,17 @@ export class MaplibreLegendControl implements IControl {
 			if (map.loaded()) {
 				const style = map.getStyle();
 				const styleUrl = style.sprite;
-				const promise = Promise.all([
-					this.loadImage(`${styleUrl}@2x.png`),
-					this.loadJson(`${styleUrl}.json`)
-				]);
-				await promise
-					.then(([image, json]) => {
-						this.setSprite(image, json);
-					})
-					.catch((err) => console.error(err));
+				if (styleUrl) {
+					const promise = Promise.all([
+						this.loadImage(`${styleUrl}@2x.png`),
+						this.loadJson(`${styleUrl}.json`)
+					]);
+					await promise
+						.then(([image, json]) => {
+							this.setSprite(image, json);
+						})
+						.catch((err) => console.error(err));
+				}
 				this.updateLegendControl();
 				map.off('idle', afterLoadListener);
 			}


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

Please describe what you changed briefly.

## Type of Pull Request
<!-- ignore-task-list-start -->
- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] Make sure all the exsiting features working well
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-legend/tree/master/.github/CONTRIBUTING.md) for more details.
