### PR TITLE
fix: Update Node.js v18 to v24

### DIFF
--- a/.changeset/fix-nodejs-v24.md
+++ b/.changeset/fix-nodejs-v24.md
@@ -1,0 +1,5 @@
+---
+"@watergis/maplibre-gl-legend": patch
+---
+
+Update Node.js from v18 to v24

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18]
+        node-version: [18, 22, 24]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: 24.x
           cache: pnpm
 
       - name: install dependencies


### PR DESCRIPTION
Thank you for submitting a pull request!

## Description

- This PR make changes of following files:
  - .github/workflows/build.yml
  - .github/workflows/release.yml
- FIX: https://github.com/watergis/maplibre-gl-legend/issues/33

### Note

- I have confirmed that pnpm install, pnpm lint, pnpm format, and pnpm build can be executed in Node.js v24.

## Type of Pull Request
<!-- ignore-task-list-start -->
- [ ] Adding a feature
- [ ] Fixing a bug
- [ ] Maintaining documents
- [x] Others (Update dependencies)
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] Make sure all the exsiting features working well
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-legend/tree/master/.github/CONTRIBUTING.md) for more details.
