### PR TITLE
fix: #37 Multiple sprite sources

### DIFF
--- a/.changeset/friendly-toes-fold.md
+++ b/.changeset/friendly-toes-fold.md
@@ -1,0 +1,5 @@
+---
+"@watergis/maplibre-gl-legend": patch
+---
+
+fix: support multiple sprite sources

--- a/packages/maplibre-gl-legend/src/lib/index.ts
+++ b/packages/maplibre-gl-legend/src/lib/index.ts
@@ -1,5 +1,11 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { ControlPosition, IControl, LayerSpecification, Map as MaplibreMap } from 'maplibre-gl';
+import {
+	ControlPosition,
+	IControl,
+	LayerSpecification,
+	Map as MaplibreMap,
+	SpriteSpecification
+} from 'maplibre-gl';
 import LegendSymbol from '@watergis/legend-symbol';
 import axios from 'axios';
 
@@ -288,6 +294,17 @@ export class MaplibreLegendControl implements IControl {
 		}
 	}
 
+	private getStyleUrl(sprite: SpriteSpecification | undefined): string | undefined {
+		if (!sprite) return;
+		if (typeof sprite === 'string') {
+			return sprite;
+		}
+		if (Array.isArray(sprite) && sprite.length) {
+			return sprite[0].url;
+		}
+		return;
+	}
+
 	public onAdd(map: MaplibreMap): HTMLElement {
 		this.map = map;
 		this.controlContainer = document.createElement('div');
@@ -345,7 +362,7 @@ export class MaplibreLegendControl implements IControl {
 		const afterLoadListener = async () => {
 			if (map.loaded()) {
 				const style = map.getStyle();
-				const styleUrl = style.sprite;
+				const styleUrl = this.getStyleUrl(style.sprite);
 				if (styleUrl) {
 					const promise = Promise.all([
 						this.loadImage(`${styleUrl}@2x.png`),


### PR DESCRIPTION
## Description
This fix adds a function which checks the sprite property of the map style if its a string or array.

When setting the map's style and adding a custom sprite, the sprite property is an array of objects with an id and url property. 

## Type of Pull Request
<!-- ignore-task-list-start -->
- [ ] Adding a feature
- [x] Fixing a bug
- [ ] Maintaining documents
- [ ] Others ()
<!-- ignore-task-list-end -->

## Verify the followings
<!-- ignore-task-list-start -->
- [x] Code is up-to-date with the `main` branch
- [x] No lint errors after `pnpm lint`
- [x] Make sure all the exsiting features working well
<!-- ignore-task-list-end -->

Refer to [CONTRIBUTING.MD](https://github.com/watergis/maplibre-gl-legend/tree/master/.github/CONTRIBUTING.md) for more details.
